### PR TITLE
add gameEnd, refactor monsterSpawn,useCardHandler bugfix gamePrepare

### DIFF
--- a/src/handlers/coreMethod/monsterMove.ts
+++ b/src/handlers/coreMethod/monsterMove.ts
@@ -41,10 +41,21 @@ export const monsterMoveStart = async (roomId: number, totalTime: number) => {
   let callme = 0;
   totalTime -= 500;
   const monsterMove = setInterval(async () => {
+    // 시간 다되면 함수 종료
+    if (Date.now() - time >= totalTime)
+      console.log('함수 실행 횟수:', callme, '함수 실행 시간:', Date.now() - time), clearInterval(monsterMove);
+
+    // characterPositions 없으면 return
     const characterPositions: { [roomId: number]: CharacterPositionData[] | undefined } | undefined =
       await getRedisData('characterPositionDatas');
-    if (characterPositions === undefined) return;
-    if (characterPositions[roomId] === undefined) return;
+    if (characterPositions === undefined) {
+      console.log('함수 실행 횟수:', callme, '함수 실행 시간:', Date.now() - time), clearInterval(monsterMove);
+      return;
+    }
+    if (characterPositions[roomId] === undefined) {
+      console.log('함수 실행 횟수:', callme, '함수 실행 시간:', Date.now() - time), clearInterval(monsterMove);
+      return;
+    }
     await monsterAttackCheck(roomData);
     callme++;
     for (let i = 0; i < monsterAiDatas[roomId].length; i++) {
@@ -126,9 +137,5 @@ export const monsterMoveStart = async (roomId: number, totalTime: number) => {
         });
       }
     }
-
-    // 시간 다되면 함수 종료
-    if (Date.now() - time >= totalTime)
-      console.log('함수 실행 횟수:', callme, '함수 실행 시간:', Date.now() - time), clearInterval(monsterMove);
   }, 100);
 };

--- a/src/handlers/coreMethod/monsterSpawn.ts
+++ b/src/handlers/coreMethod/monsterSpawn.ts
@@ -172,7 +172,7 @@ export const monsterSpawn = async (roomId: number, level: number) => {
     monsterNumber,
     position[positionIndex][0],
     position[positionIndex][1],
-    0,
+    monsterData[level].attackCool / 2,
     monsterData[level].attackRange
   );
 };

--- a/src/handlers/game/gameEndHandler.ts
+++ b/src/handlers/game/gameEndHandler.ts
@@ -1,6 +1,15 @@
-import net from 'net';
+import { gameEndNotification } from '../notification/gameEnd.js';
+import { getRoomByUserId, getUserBySocket } from '../handlerMethod.js';
+import { CustomSocket } from '../../interface/interface.js';
 
 // 게임 종료
-export const gameEndHandler = (socket: net.Socket) => {
+export const gameEndHandler = async (socket: CustomSocket) => {
+  const user = await getUserBySocket(socket);
+  const room = await getRoomByUserId(user.id);
+  if (room === null) {
+    console.error('gameEndHandler: 해당 유저가 속한 roomData를 찾을 수 없습니다.');
+    return;
+  }
+  await gameEndNotification(room.id, 2);
   console.log('게임 종료');
 };

--- a/src/handlers/game/gamePrepareHandler.ts
+++ b/src/handlers/game/gamePrepareHandler.ts
@@ -172,17 +172,17 @@ export const setCharacterInfoInit = (users: User[]) => {
 
   // 배열을 랜덤으로 섞기 (Fisher-Yates Shuffle Algorithm)
   for (let i = users.length - 1; i > 0; i--) {
-    const j = Math.round(Math.random() * (i + 1));
+    const j = Math.floor(Math.random() * (i + 1));
     [numbers[i], numbers[j]] = [numbers[j], numbers[i]];
   }
   const selectedTypes = numbers.slice(0, users.length);
 
-  // 보스가 무조건 선택되도록 하기
-  if (selectedTypes.indexOf(UserCharacterType.PINK_SLIME) === -1) {
-    console.log('보스 선택안되어서 선택되도록 변경함');
-    const j = Math.round(Math.random() * selectedTypes.length);
-    selectedTypes[j] = UserCharacterType.PINK_SLIME;
-  }
+  // // 보스가 무조건 선택되도록 하기
+  // if (selectedTypes.indexOf(UserCharacterType.PINK_SLIME) === -1) {
+  //   console.log('보스 선택안되어서 선택되도록 변경함');
+  //   const j = Math.round(Math.random() * selectedTypes.length);
+  //   selectedTypes[j] = UserCharacterType.PINK_SLIME;
+  // }
 
   // 직업 부여 랜덤 로직
   for (let i = 0; i < users.length; i++) {

--- a/src/handlers/game/gameStartHandler.ts
+++ b/src/handlers/game/gameStartHandler.ts
@@ -92,7 +92,7 @@ export const gameStartHandler = async (socket: CustomSocket, payload: Object) =>
       // 게임 종료 notification 보내기
       setTimeout(
         async () => {
-          await gameEndNotification(room.id);
+          await gameEndNotification(room.id, 4);
         },
         inGameTime * normalRound + bossGameTime
       );
@@ -168,7 +168,7 @@ export const bossPhaseNotification = async (level: number, roomId: number, sendT
       const userSocket = socketSessions[room.users[i].id];
       if (userSocket) {
         sendPacket(userSocket, config.packetType.GAME_START_NOTIFICATION, notifiData);
-        sendPacket(userSocket, config.packetType.REACTION_RESPONSE, { success: 1, failCode: 0 });
+        sendPacket(userSocket, config.packetType.REACTION_RESPONSE, { success: 1, failCode: roomId });
       }
     }
     await monsterMoveStart(roomId, bossGameTime);

--- a/src/handlers/notification/gameEnd.ts
+++ b/src/handlers/notification/gameEnd.ts
@@ -5,18 +5,16 @@ import { socketSessions } from '../../session/socketSession.js';
 import { monsterAiDatas } from '../coreMethod/monsterMove.js';
 import { RoomStateType } from '../enumTyps.js';
 import { getRedisData, setRedisData } from '../handlerMethod.js';
+import { addgRoomId, getgRoomId } from '../room/createRoomHandler.js';
 
 // 시간 안에 탈출하지 못했을 경우
-export const gameEndNotification = async (roomId: number) => {
+export const gameEndNotification = async (roomId: number, winRoleType: number) => {
   const rooms: Room[] = await getRedisData('roomData');
   let room: Room | null = null;
   for (let i = 0; i < rooms.length; i++) {
     if (rooms[i].id === roomId) room = rooms[i];
   }
-  if (!room) {
-    console.log('userSocket 방이 없음');
-    return;
-  }
+  if (!room) return;
 
   // 이미 탈출하여서 끝난 게임이면 실행 종료
   if (room.state !== RoomStateType.INGAME) {
@@ -28,19 +26,29 @@ export const gameEndNotification = async (roomId: number) => {
     if (room.users[i].character.roleType === 1) room.users.splice(i, 1), i--;
   }
   room.state = RoomStateType.WAIT;
-  await setRedisData('roomData', rooms);
+
+  // 승리한 팀의 유저 Id 찾기
+  const winnersUserId: number[] = [];
+  for (let i = 0; i < room.users.length; i++) {
+    if (room.users[i].character.roleType === winRoleType) {
+      winnersUserId.push(room.users[i].id);
+    }
+  }
 
   // 승/패 notification과 방으로 돌가가는 sendPacket 보내기
   for (let i = 0; i < room.users.length; i++) {
     const userSocket = socketSessions[room.users[i].id];
     if (userSocket) {
-      sendPacket(userSocket, config.packetType.GAME_END_NOTIFICATION, { winners: [i + 1], winType: 2 });
+      sendPacket(userSocket, config.packetType.GAME_END_NOTIFICATION, { winners: winnersUserId, winType: 0 });
     }
   }
 
-  // characterPositions 삭제하기, monsterAi 삭제하기
+  // characterPositions 삭제하기, monsterAi 삭제하기, 방Id 변경하기
   const characterPositions = await getRedisData('characterPositionDatas');
   delete characterPositions[roomId];
   await setRedisData('characterPositionDatas', characterPositions);
   delete monsterAiDatas[roomId];
+  addgRoomId();
+  room.id = getgRoomId();
+  await setRedisData('roomData', rooms);
 };

--- a/src/handlers/room/createRoomHandler.ts
+++ b/src/handlers/room/createRoomHandler.ts
@@ -5,7 +5,13 @@ import { getRedisData, getUserBySocket, setRedisData } from '../handlerMethod.js
 import { CreateRoomPayload, CustomSocket, RedisUserData, Room, User } from '../../interface/interface.js';
 import { GlobalFailCode, RoomStateType } from '../enumTyps.js';
 
-export let gRoomId = 1;
+let gRoomId: number = 1;
+export const getgRoomId = () => {
+  return gRoomId;
+};
+export const addgRoomId = () => {
+  gRoomId++;
+};
 
 export const createRoomHandler = async (socket: net.Socket, payload: Object) => {
   let failCode: Number = GlobalFailCode.NONE;


### PR DESCRIPTION
탈출로가 열려있을 때 탈출로의 trigger에 도착하면 게임을 종료시키는 기능 추가

불필요한 로직 제거 ( 보스가 반드시 선택되는 상황인데 보스 선택 안될 경우를 계산하는 로직 삭제 )

랜덤 숫자 뽑아내기에서 floor이 아니라 round 를 사용하여 보유한 캐릭터 수보다 1 높은 index가 나올 수 있는 error 수정

라운드 시작 시 몬스터 공격 쿨 타임 0 에서 최대쿨의 절반으로 수정

마나 소모 시점 변경 (2번 공격하는 스킬 사용 시 조건에 따라 마나가 반만 소모될 수 있는 현상 수정)