### PR TITLE
fix gameEndHandler.ts

### DIFF
--- a/src/gameServer/handlers/game/gameEndHandler.ts
+++ b/src/gameServer/handlers/game/gameEndHandler.ts
@@ -1,16 +1,21 @@
 import { gameEndNotification } from '../notification/gameEnd.js';
 import { getRoomByUserId, getUserIdBySocket } from '../handlerMethod.js';
-import { CustomSocket } from '../../../gameServer/interface/interface.js';
+import { CustomSocket, GameEndPayload } from '../../../gameServer/interface/interface.js';
 
 // 게임 종료
-export const gameEndHandler = async (socket: CustomSocket) => {
+export const gameEndHandler = async (socket: CustomSocket, payload: Object) => {
   const userId: number | null = await getUserIdBySocket(socket);
+  const gameEndPayload = payload as GameEndPayload;
   if (userId === null) return;
   const room = await getRoomByUserId(userId);
   if (room === null) {
     console.error('gameEndHandler: 해당 유저가 속한 roomData를 찾을 수 없습니다.');
     return;
   }
-  await gameEndNotification(room.id, 2);
+  if (gameEndPayload.reactionType === 1) {
+    await gameEndNotification(room.id, 4);
+  } else {
+    await gameEndNotification(room.id, 2);
+  }
   console.log('게임 종료');
 };

--- a/src/gameServer/handlers/game/gameStartHandler.ts
+++ b/src/gameServer/handlers/game/gameStartHandler.ts
@@ -68,6 +68,7 @@ export const gameStartHandler = async (socket: CustomSocket, payload: Object) =>
       const initGameInfo = Server.getInstance().initGameInfo;
       if (!initGameInfo) return;
       const inGameTime = initGameInfo[0].normalRoundTime;
+      //const inGameTime = 10000;
       const normalRound = initGameInfo[0].normalRoundNumber;
       const bossGameTime = initGameInfo[0].bossRoundTime;
       await setRedisData('roomData', rooms);
@@ -161,7 +162,7 @@ export const bossPhaseNotification = async (level: number, roomId: number, sendT
     const initGameInfo = Server.getInstance().initGameInfo;
     if (!initGameInfo) return;
     const bossGameTime = initGameInfo[0].bossRoundTime;
-    const gameStateData = { phaseType: PhaseType.DAY, nextPhaseAt: Date.now() + bossGameTime };
+    const gameStateData = { phaseType: PhaseType.EVENING, nextPhaseAt: Date.now() + bossGameTime };
     const notifiData = {
       gameState: gameStateData,
       users: room.users,

--- a/src/gameServer/interface/interface.ts
+++ b/src/gameServer/interface/interface.ts
@@ -289,3 +289,7 @@ export interface CardEffectNotification {
   userId: number;
   success: boolean;
 }
+
+export interface GameEndPayload {
+  reactionType: number;
+}


### PR DESCRIPTION
클라이언트에서 보스라운드에 생존자 전멸시 리퀘스트의 reactionType을 다르게 줌.
그에 따라서 조건별로 notification 호출
fix gameStartHandler.ts
보스라운드 시작 시 보내는 PhaseType 수정
update interface.ts
게임종료 페이로드를 읽기위한 인터페이스 추가